### PR TITLE
Add a vision statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# OpenSourceSA
+# Open Source Service Area
+
+A service area serving the Turing research community to facilitate open research.
+
+**Table of Contents:**
+
+- [Vision Statement](#vision-statement)
+
+---
+
+## Vision Statement
+
+This service area will work with the [Tools, Practices and Systems](https://www.turing.ac.uk/research/research-programmes/tools-practices-and-systems) research programme, [The Turing Way](https://github.com/alan-turing-institute/the-turing-way), and various research projects to build an open and reusable framework for translating research output into open contributions and/or open communities.
+This will empower researchers in the Turing community who wish to work openly to feel confident in how they structure their projects and engage stakeholders to achieve their open research goals.
+Thus facilitating more open research from within the Turing and further collaboration between the Turing and the open source community.


### PR DESCRIPTION
Add a vision statement to the project readme articulating the purpose of the service area. Inspired by: https://mozilla.github.io/open-leadership-training-series/articles/introduction-to-open-leadership/stating-your-project-vision/