### PR TITLE
Add a Ways of Working document

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A service area serving the Turing research community to facilitate open research
 **Table of Contents:**
 
 - [Vision Statement](#vision-statement)
+- [The Team](#the-team)
 
 ---
 
@@ -13,3 +14,7 @@ A service area serving the Turing research community to facilitate open research
 This service area will work with the [Tools, Practices and Systems](https://www.turing.ac.uk/research/research-programmes/tools-practices-and-systems) research programme, [The Turing Way](https://github.com/alan-turing-institute/the-turing-way), and various research projects to build an open and reusable framework for translating research output into open contributions and/or open communities.
 This will empower researchers in the Turing community who wish to work openly to feel confident in how they structure their projects and engage stakeholders to achieve their open research goals.
 Thus facilitating more open research from within the Turing and further collaboration between the Turing and the open source community.
+
+## The Team
+
+For more information on who the team are and how to get in contact with them, please see the [ways of working document](WAYS_OF_WORKING.md).

--- a/WAYS_OF_WORKING.md
+++ b/WAYS_OF_WORKING.md
@@ -1,0 +1,27 @@
+# Ways of Working
+
+This document outlines expectations and responsibilities of project members and contributors to the Open Source Service Area with regards to working on the project.
+
+## Project Team
+
+| Name         | Role                                        | % working on the project | Preferred method(s) of communication  |
+| ------------ | ------------------------------------------- | ------------------------ | ------------------------------------- |
+| Sarah Gibson | Service Area Lead / Open Developer Advocate | 40%                      | Slack: `@Sarah`, GitHub: `@sgibson91` |
+
+## Communication
+
+As well as the communication methods mentioned in the table above, the whole team can be reached for public discussion in the `#tps` channel on the [Turing's Slack workspace](https://alan-turing-institute.slack.com).
+
+## Project Management
+
+### Issues
+
+* Once completed, issues should be closed as soon as possible.
+* The team will have a fortnightly catch-up to triage open issues and agree on priorities before the next catch-up.
+
+## Commitments
+
+All the Open Source Service Area team members commit to:
+
+* making the implicit explicit by documenting their work; and
+* dedicating time to update contributing guidelines and other core documents to facilitate collaboration.


### PR DESCRIPTION
This document outlines the following:

* who is on the team
* how they prefer to be contacted individually
* where open discussions will happen in the Turing ecosphere
* what commitments the team members promise to uphold
* project management strategies